### PR TITLE
Fix Angular CLI version mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Portfolio
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.2.10.
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 19.2.14.
 
 ## Development server
 


### PR DESCRIPTION
## Summary
- update Angular CLI version to 19.2.14 in README

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686159039d2c832ca51eaa9016eac545