### PR TITLE
Fix Material button directive

### DIFF
--- a/src/app/shared/button/button.component.html
+++ b/src/app/shared/button/button.component.html
@@ -1,1 +1,1 @@
-<button matButton="filled" color="accent">{{ label }}</button>
+<button mat-flat-button color="accent">{{ label }}</button>


### PR DESCRIPTION
## Summary
- use the `mat-flat-button` directive instead of the obsolete `matButton="filled"`

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68615cce4870832cbe2a955b8577f07b