### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+.yarn/
+.pnp.*

--- a/src/app/layout/layout.component.html
+++ b/src/app/layout/layout.component.html
@@ -27,6 +27,10 @@
       <mat-icon>menu</mat-icon>
     </button>
 
+    <button mat-icon-button (click)="toggleTheme()" aria-label="Toggle theme">
+      <mat-icon>brightness_6</mat-icon>
+    </button>
+
     <mat-menu #menu="matMenu">
       <a mat-menu-item routerLink="/home" routerLinkActive="active">
         <mat-icon>home</mat-icon>

--- a/src/app/layout/layout.component.ts
+++ b/src/app/layout/layout.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ThemeService } from '../theme.service';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -26,7 +27,13 @@ export class LayoutComponent {
   currentYear = new Date().getFullYear();
   isMenuOpen = false;
 
+  constructor(private theme: ThemeService) {}
+
   toggleMenu() {
     this.isMenuOpen = !this.isMenuOpen;
+  }
+
+  toggleTheme() {
+    this.theme.toggle();
   }
 }

--- a/src/app/theme.service.ts
+++ b/src/app/theme.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private currentTheme: 'light' | 'dark' = 'light';
+
+  constructor() {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('theme') : null;
+    if (stored === 'light' || stored === 'dark') {
+      this.currentTheme = stored;
+    } else if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      this.currentTheme = 'dark';
+    }
+    this.applyTheme();
+  }
+
+  toggle(): void {
+    this.currentTheme = this.currentTheme === 'light' ? 'dark' : 'light';
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', this.currentTheme);
+    }
+    this.applyTheme();
+  }
+
+  private applyTheme(): void {
+    if (typeof document === 'undefined') return;
+    document.documentElement.setAttribute('data-theme', this.currentTheme);
+  }
+}

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -1,22 +1,44 @@
 @use "@angular/material" as mat;
 @use "./generated/themes/dark/green/_theme-colors" as green-theme-colors;
 @use "./colors" as colors;
+
+$light-theme: mat.define-theme(
+  (
+    color: (
+      theme-type: light,
+      primary: green-theme-colors.$primary-palette,
+      tertiary: green-theme-colors.$tertiary-palette,
+    ),
+    typography: Inter,
+    density: 0,
+  )
+);
+
+$dark-theme: mat.define-theme(
+  (
+    color: (
+      theme-type: dark,
+      primary: green-theme-colors.$primary-palette,
+      tertiary: green-theme-colors.$tertiary-palette,
+    ),
+    typography: Inter,
+    density: 0,
+  )
+);
+
 html {
   color-scheme: light dark;
-  @include mat.theme(
-    (
-      color: green-theme-colors.$primary-palette,
-      tertiary: green-theme-colors.$tertiary-palette,
-      typography: Inter,
-      density: 0,
-    )
-  );
-
+  @include mat.theme($light-theme);
   @include mat.toolbar-overrides(
     (
       container-background-color: transparent,
-      container-text-color: colors.$color-accent,)
+      container-text-color: colors.$color-accent,
+    )
   );
+}
+
+html[data-theme='dark'] {
+  @include mat.theme($dark-theme);
 }
 
 // .custom-theme {


### PR DESCRIPTION
## Summary
- support dark and light variants using Angular Material theming
- add a ThemeService and toggle button
- ignore yarn and pnp files

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616153288c832cabb45990170c9e37