### PR TITLE
Add configurable light and dark themes

### DIFF
--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -2,6 +2,37 @@
 @use "./generated/themes/dark/green/_theme-colors" as green-theme-colors;
 @use "./colors" as colors;
 
+// Define theme-specific CSS variable sets
+$light-vars: (
+  surface: #ffffff,
+  on-surface: #1f2937,
+  primary: #10b981,
+  on-primary: #ffffff,
+  accent: #10b981,
+  surface-variant: #f0f0f0,
+  on-surface-variant: #4b5563,
+  outline: #d1d5db,
+  border: #e5e7eb,
+);
+
+$dark-vars: (
+  surface: #181818,
+  on-surface: #f9fafb,
+  primary: #10b981,
+  on-primary: #000000,
+  accent: #10b981,
+  surface-variant: #374151,
+  on-surface-variant: #a0aec0,
+  outline: #4b5563,
+  border: #333333,
+);
+
+@mixin theme-vars($map) {
+  @each $name, $value in $map {
+    --theme-#{$name}: #{$value};
+  }
+}
+
 $light-theme: mat.define-theme(
   (
     color: (
@@ -35,10 +66,12 @@ html {
       container-text-color: colors.$color-accent,
     )
   );
+  @include theme-vars($light-vars);
 }
 
 html[data-theme='dark'] {
   @include mat.theme($dark-theme);
+  @include theme-vars($dark-vars);
 }
 
 // .custom-theme {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,21 +1,11 @@
 @use './theme';
 
+
 :root {
   margin: 0;
   padding: 0;
-
-  /* Theme CSS custom properties */
-  --theme-surface: var(--mdc-theme-surface, #ffffff);
-  --theme-on-surface: var(--mdc-theme-on-surface, #000000);
-  --theme-primary: var(--mdc-theme-primary, #10b981);
-  --theme-on-primary: var(--mdc-theme-on-primary, #ffffff);
-  --theme-surface-variant: var(--mdc-theme-surface-variant, #f0f0f0);
-  --theme-on-surface-variant: var(--mdc-theme-on-surface-variant, #666666);
-  --theme-outline: var(--mdc-theme-outline, #d1d5db);
-  --theme-border: var(--mdc-theme-outline, #333333);
   --theme-shadow: rgba(0, 0, 0, 0.08);
   --theme-shadow-hover: rgba(0, 0, 0, 0.12);
-  --theme-accent: var(--mdc-theme-primary, #10b981);
 }
 
 html,


### PR DESCRIPTION
## Summary
- tweak global styles
- define light and dark theme variables and apply them

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616373f8d8832c9a2f7abc65beb0a9