### PR TITLE
Refactor SCSS to rely on theme variables

### DIFF
--- a/src/app/layout/layout.component.scss
+++ b/src/app/layout/layout.component.scss
@@ -160,9 +160,9 @@ mat-nav-list {
 
 .footer {
   width: 100%;
-  background: #111;
-  color: #fff;
-  border-top: 1px solid #222;
+  background: var(--theme-surface);
+  color: var(--theme-on-surface);
+  border-top: 1px solid var(--theme-border);
   padding: 16px 0;
   display: flex;
   flex-direction: column;
@@ -196,7 +196,7 @@ mat-nav-list {
 
       .footer-tagline {
         font-size: 1rem;
-        color: #bbb;
+        color: var(--theme-on-surface-variant);
         margin-bottom: 4px;
       }
 
@@ -204,14 +204,14 @@ mat-nav-list {
         display: flex;
         gap: 16px;
         font-size: 0.95rem;
-        color: #bbb;
+        color: var(--theme-on-surface-variant);
 
         a {
-          color: #63d219;
+          color: var(--theme-accent);
           text-decoration: underline dotted;
 
           &:hover {
-            color: #fff;
+            color: var(--theme-on-surface);
           }
         }
 
@@ -229,16 +229,16 @@ mat-nav-list {
       align-items: center;
 
       a {
-        color: #fff;
+        color: var(--theme-on-surface);
         text-decoration: none;
         transition: color 0.2s;
 
         &:hover {
-          color: #63d219;
+          color: var(--theme-accent);
         }
 
         mat-icon {
-          color: #fff;
+          color: var(--theme-on-surface);
           font-size: 22px;
           vertical-align: middle;
         }
@@ -256,7 +256,7 @@ mat-nav-list {
     justify-content: space-between;
     align-items: center;
     font-size: 0.92rem;
-    color: #bbb;
+    color: var(--theme-on-surface-variant);
 
     .footer-made {
       display: flex;

--- a/src/app/pages/work-ex/work-ex.component.scss
+++ b/src/app/pages/work-ex/work-ex.component.scss
@@ -9,8 +9,8 @@
   margin: 16px 0;
   border-radius: 12px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  background: var(--theme-surface, var(--mat-card-background, #fff));
-  color: var(--theme-on-surface, var(--mat-card-text, #222));
+  background: var(--theme-surface, var(--mat-card-background));
+  color: var(--theme-on-surface, var(--mat-card-text));
   transition:
     transform 0.2s ease-in-out,
     box-shadow 0.2s ease-in-out;
@@ -35,7 +35,7 @@ mat-card-header {
   margin: 0;
   font-size: 1.5rem;
   font-weight: 500;
-  color: var(--theme-primary, #1976d2);
+  color: var(--theme-primary);
 }
 
 .date-range {
@@ -63,7 +63,7 @@ mat-card-content {
   h4 {
     margin: 0 0 16px;
     font-size: 1.1rem;
-    color: var(--theme-on-surface, #222);
+    color: var(--theme-on-surface);
   }
 
   ul {
@@ -85,7 +85,7 @@ mat-card-content {
         width: 6px;
         height: 6px;
         border-radius: 50%;
-        background-color: var(--theme-primary, #1976d2);
+        background-color: var(--theme-primary);
       }
     }
   }
@@ -95,7 +95,7 @@ mat-card-content {
   h4 {
     margin: 0 0 16px;
     font-size: 1.1rem;
-    color: var(--theme-on-surface, #222);
+    color: var(--theme-on-surface);
   }
 }
 
@@ -108,8 +108,8 @@ mat-card-content {
 .tech-chip {
   padding: 6px 12px;
   border-radius: 16px;
-  background-color: var(--theme-primary, #1976d2);
-  color: var(--theme-on-primary, #fff);
+  background-color: var(--theme-primary);
+  color: var(--theme-on-primary);
   font-size: 0.875rem;
   transition: transform 0.2s ease;
 
@@ -200,34 +200,34 @@ mat-card-content {
 
   .mat-vertical-stepper-header {
     background: transparent;
-    color: var(--theme-on-surface, #222);
+    color: var(--theme-on-surface);
     font-weight: 500;
     
     &.cdk-focused, &.cdk-program-focused, &:hover {
-      color: var(--theme-primary, #1976d2);
+      color: var(--theme-primary);
     }
   }
 
   .mat-step-icon, .mat-step-icon-selected, .mat-step-icon-state-edit, .mat-step-icon-state-done, .mat-step-icon-state-number {
-    background: var(--theme-surface, #fff);
-    color: var(--theme-primary, #1976d2);
-    border: 1.5px solid var(--theme-primary, #1976d2);
+    background: var(--theme-surface);
+    color: var(--theme-primary);
+    border: 1.5px solid var(--theme-primary);
     font-weight: bold;
     box-shadow: 0 1px 4px rgba(0,0,0,0.08);
   }
 
   .mat-step-icon-selected {
-    background: var(--theme-primary, #1976d2);
-    color: var(--theme-on-primary, #fff);
-    border-color: var(--theme-primary, #1976d2);
+    background: var(--theme-primary);
+    color: var(--theme-on-primary);
+    border-color: var(--theme-primary);
   }
 
   .mat-step-label {
-    color: var(--theme-on-surface, #222);
+    color: var(--theme-on-surface);
   }
 
   .mat-step-label-active {
-    color: var(--theme-primary, #1976d2);
+    color: var(--theme-primary);
     font-weight: 600;
   }
 }
@@ -235,26 +235,26 @@ mat-card-content {
 // Material stepper overrides for strong visibility
 :host ::ng-deep .mat-vertical-stepper-header {
   background: transparent !important;
-  color: var(--theme-on-surface, #222) !important;
+  color: var(--theme-on-surface) !important;
   font-weight: 500;
 }
 :host ::ng-deep .mat-step-icon {
-  background: var(--theme-surface, #fff) !important;
-  color: var(--theme-primary, #10b981) !important;
-  border: 2px solid var(--theme-primary, #10b981) !important;
+  background: var(--theme-surface) !important;
+  color: var(--theme-primary) !important;
+  border: 2px solid var(--theme-primary) !important;
   // font-weight: bold;
   box-shadow: 0 1px 4px rgba(0,0,0,0.08);
 }
 :host ::ng-deep .mat-step-icon-selected {
-  background: var(--theme-primary, #10b981) !important;
-  color: var(--theme-on-primary, #fff) !important;
-  border-color: var(--theme-primary, #10b981) !important;
+  background: var(--theme-primary) !important;
+  color: var(--theme-on-primary) !important;
+  border-color: var(--theme-primary) !important;
 }
 :host ::ng-deep .mat-step-label {
-  color: var(--theme-on-surface, #222) !important;
+  color: var(--theme-on-surface) !important;
 }
 :host ::ng-deep .mat-step-label-active {
-  color: var(--theme-primary, #10b981) !important;
+  color: var(--theme-primary) !important;
   font-weight: 600;
 }
 :host ::ng-deep .stepper-company-icon {
@@ -262,8 +262,8 @@ mat-card-content {
   height: 22px;
   object-fit: contain;
   border-radius: 4px;
-  background: var(--theme-surface, #fff);
-  border: 2px solid var(--theme-primary, #10b981);
+  background: var(--theme-surface);
+  border: 2px solid var(--theme-primary);
   box-shadow: 0 1px 4px rgba(0,0,0,0.08);
   display: inline-block;
   vertical-align: middle;

--- a/src/app/shared/components/experience-card/experience-card.component.scss
+++ b/src/app/shared/components/experience-card/experience-card.component.scss
@@ -3,10 +3,10 @@
   margin: 16px;
   border-radius: 12px;
   transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-  background: var(--mat-card-background, var(--theme-surface, #fff));
-  color: var(--mat-card-text, var(--theme-on-surface, #222));
+  background: var(--mat-card-background, var(--theme-surface));
+  color: var(--mat-card-text, var(--theme-on-surface));
   box-shadow: 0 4px 16px var(--theme-shadow, rgba(0,0,0,0.08));
-  border: 1px solid var(--theme-outline, #e0e0e0);
+  border: 1px solid var(--theme-outline);
 
   &:hover {
     transform: translateY(-4px);
@@ -29,8 +29,8 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: var(--theme-surface-variant, #f5f5f5);
-      border: 1px solid var(--theme-outline, #eee);
+      background: var(--theme-surface-variant);
+      border: 1px solid var(--theme-outline);
 
       img {
         width: 100%;
@@ -53,14 +53,14 @@
           margin: 0;
           font-size: 1.5rem;
           font-weight: 600;
-          color: var(--mat-primary, var(--theme-primary, #222));
+          color: var(--mat-primary, var(--theme-primary));
         }
 
         .location {
           display: flex;
           align-items: center;
           gap: 4px;
-          color: var(--mat-secondary, var(--theme-on-surface-variant, #666));
+          color: var(--mat-secondary, var(--theme-on-surface-variant));
           font-size: 0.9rem;
 
           mat-icon {
@@ -74,7 +74,7 @@
       .role {
         margin: 0;
         font-size: 1.1rem;
-        color: var(--mat-card-text, var(--theme-on-surface, #333));
+        color: var(--mat-card-text, var(--theme-on-surface));
         font-weight: 500;
       }
 
@@ -83,7 +83,7 @@
         align-items: center;
         gap: 12px;
         margin-top: 8px;
-        color: var(--mat-secondary, var(--theme-on-surface-variant, #666));
+        color: var(--mat-secondary, var(--theme-on-surface-variant));
         font-size: 0.9rem;
 
         .date-range {
@@ -95,7 +95,7 @@
             font-size: 18px;
             width: 18px;
             height: 18px;
-            color: var(--theme-primary, #1976d2);
+            color: var(--theme-primary);
           }
         }
 
@@ -103,7 +103,7 @@
           &::before {
             content: '•';
             margin-right: 8px;
-            color: var(--theme-on-surface-variant, #bbb);
+            color: var(--theme-on-surface-variant);
           }
         }
       }
@@ -112,7 +112,7 @@
 
   mat-card-content {
     padding: 16px;
-    color: var(--mat-card-text, var(--theme-on-surface, #222));
+      color: var(--mat-card-text, var(--theme-on-surface));
 
     .description {
       ul {
@@ -121,7 +121,7 @@
         
         li {
           margin-bottom: 8px;
-          color: var(--mat-card-text, var(--theme-on-surface, #222));
+          color: var(--mat-card-text, var(--theme-on-surface));
           line-height: 1.5;
 
           &:last-child {
@@ -137,7 +137,7 @@
       h4 {
         margin: 0 0 12px;
         font-size: 1rem;
-        color: var(--mat-card-text, var(--theme-on-surface, #222));
+        color: var(--mat-card-text, var(--theme-on-surface));
       }
 
       .skills-container {
@@ -152,15 +152,15 @@
           padding: 6px 12px;
           border-radius: 16px;
           box-shadow: 0 1px 2px rgba(0,0,0,0.04);
-          border: 1px solid var(--mat-chip-border, var(--theme-outline, #e0e0e0));
-          background: var(--mat-chip-bg, var(--theme-surface-variant, #f0f0f0));
-          color: var(--mat-chip-text, var(--theme-on-surface-variant, #222));
+          border: 1px solid var(--mat-chip-border, var(--theme-outline));
+          background: var(--mat-chip-bg, var(--theme-surface-variant));
+          color: var(--mat-chip-text, var(--theme-on-surface-variant));
           font-size: 0.9rem;
           font-weight: 500;
           transition: background-color 0.2s ease;
 
           &:hover {
-            background-color: var(--theme-surface-variant-hover, #e5e5e5);
+            background-color: var(--theme-surface-variant-hover);
           }
 
           mat-icon, .skill-icon {

--- a/src/app/shared/components/footer/footer.component.scss
+++ b/src/app/shared/components/footer/footer.component.scss
@@ -1,6 +1,6 @@
 .footer {
-  background-color: var(--theme-surface, #181818);
-  color: var(--theme-on-surface, #fff);
+  background-color: var(--theme-surface);
+  color: var(--theme-on-surface);
   padding: 3rem 2rem;
   font-family: "Inter", sans-serif;
 
@@ -14,33 +14,33 @@
     }
     .footer-brand {
       max-width: 400px;
-      h3 {
-        font-size: 1.5rem;
-        color: var(--theme-accent, #63d219);
-      }
+        h3 {
+          font-size: 1.5rem;
+          color: var(--theme-accent);
+        }
       p {
         margin-top: 0.5rem;
         line-height: 1.6;
         font-size: 0.95rem;
       }
-      .social-icons {
-        color: #fff;
+        .social-icons {
+          color: var(--theme-on-surface);
         display: flex;
         gap: 1rem;
         margin-top: 1rem;
-        a,
-        img,
-        svg,
-        mat-icon {
-          color: #fff;
+          a,
+          img,
+          svg,
+          mat-icon {
+            color: var(--theme-on-surface);
           width: 22px;
           height: 22px;
           filter: brightness(0.8);
           transition: filter 0.2s, color 0.2s;
-          &:hover {
-            filter: brightness(1.2);
-            color: var(--theme-on-surface, #63d219);
-          }
+            &:hover {
+              filter: brightness(1.2);
+              color: var(--theme-accent);
+            }
         }
       }
     }
@@ -56,21 +56,21 @@
           font-weight: 600;
           font-size: 1rem;
         }
-        a {
-          font-size: 0.9rem;
-          color: var(--theme-on-surface, #fff);
-          text-decoration: none;
-          transition: color 0.2s;
-          &:hover {
-            color: var(--theme-accent, #63d219);
+          a {
+            font-size: 0.9rem;
+            color: var(--theme-on-surface);
+            text-decoration: none;
+            transition: color 0.2s;
+            &:hover {
+              color: var(--theme-accent);
+            }
           }
-        }
       }
     }
   }
   .footer-bottom {
     margin-top: 2rem;
-    border-top: 1px solid var(--theme-border, #333);
+    border-top: 1px solid var(--theme-border);
     padding-top: 1.5rem;
     display: flex;
     flex-direction: column;
@@ -86,10 +86,10 @@
       gap: 1.25rem;
       a {
         text-decoration: none;
-        color: var(--theme-on-surface, #fff);
+        color: var(--theme-on-surface);
         transition: color 0.2s;
         &:hover {
-          color: var(--theme-accent, #63d219);
+          color: var(--theme-accent);
         }
       }
     }


### PR DESCRIPTION
## Summary
- replace hex colors with CSS variables in experience card styles
- update footer styles to use theme variables
- adjust layout footer styles to use theme variables
- clean work experience styles by removing color hex fallbacks

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616a564084832cba19ea7e881e8e35